### PR TITLE
Allow for dynamic prefix for images, based on crate ID.

### DIFF
--- a/src/components/views/SubDocImage.js
+++ b/src/components/views/SubDocImage.js
@@ -12,10 +12,15 @@ const SubDocImage = function (data) {
         imagePath = data.config.prefix + dataValue;
       }
     } else {
-      dataValue = data.value;
+      dataValue = data.value;      
       if (data.config.prefix) {
         imagePath = data.config.prefix + dataValue;
-      } else {
+      } 
+      else if (data.config.inCrate) {
+        imagePath = data.ocfl_path + "/" + data.crate_uri[0] + "/" + data.value;
+        console.log(imagePath)
+      }
+      else {
         imagePath = dataValue
       }
     }

--- a/src/components/views/ViewTable.js
+++ b/src/components/views/ViewTable.js
@@ -139,7 +139,7 @@ const ViewTable = async function (data, doc) {
           const valueHtml = renderValue(data, sdcf, doc);
           if (valueHtml) {
             const row = $('<div class="row">');
-            const subDoc = SubDocImage({config: sdcf, value: valueHtml, element: row});
+            const subDoc = SubDocImage({config: sdcf, value: valueHtml, element: row, ocfl_path: data.config.apis.ocfl, crate_uri: data.main.doc.uri_id});
             nonEmptyDiv = true;
             list.append(subDoc);
           }


### PR DESCRIPTION
This builds on the SubDocImage code, but instead of having a static prefix, in the config you can specify 
`"inCrate": "True"`
and it will prefix the path for the crate in the OCFL repository before the field specified.
e.g. 
`src="ocfl/f184debd-effa-4f91-ae88-15b958be7858/out_Man_01_November2020_December2020_WORKING.png"`

I've tested on the Seafood Collection and this works, and shouldn't break anything since it just adds some fields to the SubDocImage call and then only requires them if config specifies if it's true